### PR TITLE
Changes regarding const member functions and interface issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ options:
 * "alt_bn128":
    an alternative to "bn128", somewhat slower but avoids dynamic code generation.
 
+* "mcl_bn128":
+   an alternative to "bn128", using the new MCL elliptic cuve library. Somewhat slower on x86-64 but supported and optimized for different architectures.
+
 Note that bn128 requires an x86-64 CPU while the other curve choices
 should be architecture-independent; see [portability](#portability).
 

--- a/src/algebra/curves/mcl_bn128/mcl_bn128_g1.cpp
+++ b/src/algebra/curves/mcl_bn128/mcl_bn128_g1.cpp
@@ -52,8 +52,9 @@ void mcl_bn128_G1::print() const
     }
     else
     {
-        pt.normalize();
-        std::cout << "(" << pt.x << " : " << pt.y << " : " << pt.z << ")\n";
+    	auto _pt(pt);
+    	_pt.normalize();
+        std::cout << "(" << _pt.x << " : " << _pt.y << " : " << _pt.z << ")\n";
     }
 }
 
@@ -168,26 +169,27 @@ mcl_bn128_G1 mcl_bn128_G1::random_element()
 
 std::ostream& operator<<(std::ostream &out, const mcl_bn128_G1 &g)
 {
-    g.pt.normalize();
+	auto g_pt(g.pt);
+    g_pt.normalize();
 
     out << (g.is_zero() ? '1' : '0') << OUTPUT_SEPARATOR;
 
 #ifdef NO_PT_COMPRESSION
     /* no point compression case */
 #ifndef BINARY_OUTPUT
-    out << g.pt.x << OUTPUT_SEPARATOR << g.pt.y;
+    out << g_pt.x << OUTPUT_SEPARATOR << g_pt.y;
 #else
-    out.write((char*) &g.pt, sizeof(g.pt));
+    out.write((char*) &g_pt, sizeof(g_pt));
 #endif
 
 #else
     /* point compression case */
 #ifndef BINARY_OUTPUT
-    out << g.pt.x;
+    out << g_pt.x;
 #else
-    out.write((char*) &g.pt.x, sizeof(g.pt.x));
+    out.write((char*) &g_pt.x, sizeof(g_pt.x));
 #endif
-    out << OUTPUT_SEPARATOR << (g.pt.y.getUnit()[0] & 1 ? '1' : '0');
+    out << OUTPUT_SEPARATOR << (g_pt.y.getUnit()[0] & 1 ? '1' : '0');
 #endif
 
     return out;

--- a/src/algebra/curves/mcl_bn128/mcl_bn128_g2.cpp
+++ b/src/algebra/curves/mcl_bn128/mcl_bn128_g2.cpp
@@ -44,8 +44,9 @@ void mcl_bn128_G2::print() const
     }
     else
     {
-        pt.normalize();
-        std::cout << "(" << pt.x << " : " << pt.y << " : " << pt.z << ")\n";
+        auto _pt(pt);
+        _pt.normalize();
+        std::cout << "(" << _pt.x << " : " << _pt.y << " : " << _pt.z << ")\n";
     }
 }
 
@@ -165,27 +166,28 @@ mcl_bn128_G2 mcl_bn128_G2::random_element()
 
 std::ostream& operator<<(std::ostream &out, const mcl_bn128_G2 &g)
 {
-    g.pt.normalize();
+    auto g_pt(g.pt);
+    g_pt.normalize();
 
     out << (g.is_zero() ? '1' : '0') << OUTPUT_SEPARATOR;
 
 #ifdef NO_PT_COMPRESSION
     /* no point compression case */
 #ifndef BINARY_OUTPUT
-    out << g.pt.x.a << OUTPUT_SEPARATOR << g.pt.x.b << OUTPUT_SEPARATOR;
-    out << g.pt.y.a << OUTPUT_SEPARATOR << g.pt.y.b;
+    out << g_pt.x.a << OUTPUT_SEPARATOR << g_pt.x.b << OUTPUT_SEPARATOR;
+    out << g_pt.y.a << OUTPUT_SEPARATOR << g_pt.y.b;
 #else
-    out.write((char*) &g.pt, sizeof(g.pt));
+    out.write((char*) &g_pt, sizeof(g_pt));
 #endif
 
 #else
     /* point compression case */
 #ifndef BINARY_OUTPUT
-    out << g.pt.x.a << OUTPUT_SEPARATOR << g.pt.x.b;
+    out << g_pt.x.a << OUTPUT_SEPARATOR << g_pt.x.b;
 #else
-    out.write((char*) &g.pt.x, sizeof(g.pt.x));
+    out.write((char*) &g_pt.x, sizeof(g_pt.x));
 #endif
-    out << OUTPUT_SEPARATOR << (g.pt.y.a.getUnit()[0] & 1 ? '1' : '0');
+    out << OUTPUT_SEPARATOR << (g_pt.y.a.getUnit()[0] & 1 ? '1' : '0');
 #endif
 
     return out;

--- a/src/algebra/curves/mcl_bn128/mcl_bn128_pairing.cpp
+++ b/src/algebra/curves/mcl_bn128/mcl_bn128_pairing.cpp
@@ -140,7 +140,7 @@ mcl_bn128_Fq12 mcl_bn128_ate_miller_loop(const mcl_bn128_ate_G1_precomp &precP,
                                  const mcl_bn128_ate_G2_precomp &precQ)
 {
     mcl_bn128_Fq12 f;
-    mcl::bn256::BN::precomputedMillerLoop(f.elem, precQ.coeffs, precP.P);
+    mcl::bn256::BN::precomputedMillerLoop(f.elem, precP.P, precQ.coeffs);
     return f;
 }
 
@@ -150,7 +150,7 @@ mcl_bn128_Fq12 mcl_bn128_double_ate_miller_loop(const mcl_bn128_ate_G1_precomp &
                                         const mcl_bn128_ate_G2_precomp &precQ2)
 {
     mcl_bn128_Fq12 f;
-    mcl::bn256::BN::precomputedMillerLoop2(f.elem, precQ1.coeffs, precP1.P, precQ2.coeffs, precP2.P);
+    mcl::bn256::BN::precomputedMillerLoop2(f.elem, precP1.P, precQ1.coeffs, precP2.P, precQ2.coeffs);
     return f;
 }
 


### PR DESCRIPTION
Some member functions declared const had pt.normalize(), so created an auto copy and utilised that.
The calls to some functions in the MCL library had jumbled up parameters, so fixed that.
Updated Readme with MCL curve choice.